### PR TITLE
Add openai runtimes

### DIFF
--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,7 +1,19 @@
-import { xai } from '@ai-sdk/xai';
+import { xai } from "@ai-sdk/xai";
+import { createOpenAI } from "@ai-sdk/openai";
 
-// Export xai instance for direct use
-export { xai };
+// X-AI runtime ➜ Grok
+export const grok = xai("grok-4-0709");
 
-// Export configured grok model
-export const grokModel = xai('grok-4-0709'); 
+// Native OpenAI runtime
+const openai = createOpenAI();
+export const o3     = openai("o3");
+export const gpt41  = openai("gpt-4.1");
+
+// Helper alias → returns the right runtime at runtime
+export function pickModel(id: "grok-4-0709" | "o3" | "gpt-4.1") {
+  switch (id) {
+    case "o3":        return o3;
+    case "gpt-4.1":   return gpt41;
+    default:           return grok;
+  }
+}

--- a/src/tests/ai.test.ts
+++ b/src/tests/ai.test.ts
@@ -1,32 +1,26 @@
-import { xai, grokModel } from '@/lib/ai';
+import { grok, o3, gpt41, pickModel } from '@/lib/ai';
 
 describe('AI Module Tests', () => {
-  describe('xai export', () => {
-    it('should export xai function', () => {
-      expect(xai).toBeDefined();
-      expect(typeof xai).toBe('function');
+  describe('grok runtime', () => {
+    it('should export configured grok runtime', () => {
+      expect(grok).toBeDefined();
+      expect(grok).toHaveProperty('modelId');
+      expect(grok.modelId).toBe('grok-4-0709');
     });
   });
 
-  describe('grokModel export', () => {
-    it('should export configured grok model', () => {
-      expect(grokModel).toBeDefined();
-      expect(grokModel).toHaveProperty('modelId');
-      expect(grokModel.modelId).toBe('grok-4-0709');
-    });
-
-    it('should have correct model configuration', () => {
-      expect(grokModel).toHaveProperty('provider');
-      expect(grokModel.provider).toBeDefined();
+  describe('openai runtimes', () => {
+    it('should export o3 and gpt-4.1 runtimes', () => {
+      expect(o3.modelId).toBe('o3');
+      expect(gpt41.modelId).toBe('gpt-4.1');
     });
   });
 
-  describe('model instantiation', () => {
-    it('should create XAI provider with custom model', () => {
-      const model1 = xai('grok-4-0709');
-      const model2 = xai('grok-4-0709');
-      expect(model1.modelId).toBe('grok-4-0709');
-      expect(model2.modelId).toBe('grok-4-0709');
+  describe('pickModel helper', () => {
+    it('should return the correct runtime for each id', () => {
+      expect(pickModel('grok-4-0709')).toBe(grok);
+      expect(pickModel('o3')).toBe(o3);
+      expect(pickModel('gpt-4.1')).toBe(gpt41);
     });
   });
-}); 
+});


### PR DESCRIPTION
## Summary
- add OpenAI runtimes and model helper in `ai.ts`
- update AI test suite to check new exports

## Testing
- `npm run build` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871ffb6f5348328a2cd37415bea61f8